### PR TITLE
Add handling for HIDDEN_DUE_TO_SECURITY_REASONS value for `requestParameters.tagSpecificationSet`

### DIFF
--- a/runinstances/event.go
+++ b/runinstances/event.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 )
 
+// Records represent the CloudTrail records
 type Records struct {
 	Records []Event `json:"Records"`
 }
@@ -148,11 +149,16 @@ type IamInstanceProfile struct {
 	Name string `json:"name"`
 }
 
+// TagSpecificationSetOrHidden represents either a set of tag specifications or
+// a hidden marker indicating that the tag specifications are hidden for
+// security reasons.
 type TagSpecificationSetOrHidden struct {
 	IsHidden bool
 	Tags     *TagSpecificationSet
 }
 
+// UnmarshalJSON custom unmarshals TagSpecificationSetOrHidden from JSON,
+// handling both hidden values and valid tag specifications.
 func (t *TagSpecificationSetOrHidden) UnmarshalJSON(data []byte) error {
 	var hidden string
 	if err := json.Unmarshal(data, &hidden); err == nil {

--- a/runinstances/testdata/runinstances.json
+++ b/runinstances/testdata/runinstances.json
@@ -1,0 +1,93 @@
+{
+    "Records": [
+      {
+        "eventVersion": "1.08",
+        "userIdentity": {
+          "type": "IAMUser",
+          "principalId": "ABCDEFGHIJKLMN",
+          "arn": "arn:aws:iam::123456789012:user/example",
+          "accountId": "123456789012",
+          "accessKeyId": "ABCDEFEXAMPLEKEY",
+          "sessionContext": {
+            "sessionIssuer": {
+              "type": "Role",
+              "principalId": "ABCDEFGHIJKLMN",
+              "arn": "arn:aws:iam::123456789012:role/example-role",
+              "accountId": "123456789012",
+              "userName": "example-role"
+            },
+            "attributes": {
+              "creationDate": "2023-01-01T12:00:00Z",
+              "mfaAuthenticated": "true"
+            },
+            "webIdFederationData": {}
+          }
+        },
+        "eventTime": "2024-11-07T12:34:56Z",
+        "eventSource": "ec2.amazonaws.com",
+        "eventName": "RunInstances",
+        "awsRegion": "us-west-2",
+        "sourceIPAddress": "192.0.2.0",
+        "userAgent": "console.amazonaws.com",
+        "requestParameters": {
+          "instancesSet": {
+            "items": [
+              {
+                "imageId": "ami-123456",
+                "minCount": 1,
+                "maxCount": 1,
+                "keyName": "example-key"
+              }
+            ]
+          },
+          "tagSpecificationSet": "HIDDEN_DUE_TO_SECURITY_REASONS",
+          "userData": "example-user-data",
+          "instanceType": "t2.micro",
+          "availabilityZone": "us-west-2a",
+          "tenancy": "default",
+          "monitoring": {
+            "enabled": true
+          },
+          "disableApiTermination": false,
+          "disableApiStop": false,
+          "clientToken": "token12345",
+          "networkInterfaceSet": {
+            "items": [
+              {
+                "deviceIndex": 0,
+                "subnetId": "subnet-12345",
+                "deleteOnTermination": true,
+                "associatePublicIpAddress": true,
+                "groupSet": {
+                  "items": [
+                    {
+                      "groupId": "sg-12345"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "iamInstanceProfile": {
+            "name": "example-profile"
+          }
+        },
+        "responseElements": {
+          "requestId": "request-12345",
+          "reservationId": "r-12345",
+          "ownerId": "123456789012"
+        },
+        "eventID": "e72fd221-3cbf-4410-9eda-586f4d732f88",
+        "readOnly": false,
+        "eventType": "AwsApiCall",
+        "managementEvent": true,
+        "recipientAccountId": "123456789012",
+        "eventCategory": "Management",
+        "tlsDetails": {
+          "tlsVersion": "TLSv1.2",
+          "cipherSuite": "ECDHE-RSA-AES128-GCM-SHA256",
+          "clientProvidedHostHeader": "ec2.amazonaws.com"
+        }
+      }
+    ]
+}


### PR DESCRIPTION
Add handling for `HIDDEN_DUE_TO_SECURITY_REASONS` value for `requestParameters.tagSpecificationSet`

## Error
```
json: cannot unmarshal string into Go struct field RequestParameters.Records.requestParameters.tagSpecificationSet of type runinstances.TagSpecificationSet
```